### PR TITLE
Add an all_tags field on the conversations model

### DIFF
--- a/models/conversations.sql
+++ b/models/conversations.sql
@@ -14,6 +14,7 @@ select
     {{ dbt_utils.star(from=ref('base_conversations'), except=["mailbox_name"], relation_alias="c") }}
     , m.name as mailbox_name
     , t.tag as tags
+    , (select string_agg(tag, ' ') from unnest(t.tag)) as all_tags
     , exists(
         select *
         from unnest(t.tag)


### PR DESCRIPTION
Related to [this conversation](https://paper.dropbox.com/doc/Project-Help-Scout-Data-in-Looker--AYqPS6JNIeQz9aCgb9maZFqAAg-1oH9m9OGU3az4PLj4FJ9i#:uid=350758695082430749093195&h2=Issue-with-Tags) 

Adding a comma delimited list of tags on each conversation. This can be used for display purposes but also is handy to filter on like in this case.